### PR TITLE
Fixed broken CSS link in visual_v02.html caused by incorrect static path

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -28,6 +28,10 @@ def create_app(config_name="development"):
     @app.route('/signup')
     def signup():
         return render_template('auth/signup.html')
+
+    @app.route('/visual')
+    def visual():
+        return render_template('user/visual_v02.html')
     
     # login_manager = LoginManager()
     # login_manager.init_app(app)

--- a/app/templates/user/visual_v02.html
+++ b/app/templates/user/visual_v02.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Crypto Holdings</title>
-  <link rel="stylesheet" href="visual_v02.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/visual_v02.css') }}">
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.js"></script>
 </head>
 <body>


### PR DESCRIPTION
## Changes Made
- Updated <link> to use {{ url_for('static', filename='css/visual_v02.css') }}
- Added temporary /visual route in `__init__.py` to allow direct page access (http://127.0.0.1:5000/visual)

## Notes
- Route /visual is temporary and may be removed after Deliverable 1
- No structural changes to page content made
- Styling now loads correctly when running Flask server