### PR TITLE
Feature/file upload basic

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,9 +5,11 @@ import logging
 def create_app(config_name="development"):
     app = Flask(__name__, static_folder='static', template_folder='templates')
 
+    app.config['SECRET_KEY'] = 'password' # CHANGE THIS TO SOMETHING MORE SECURE BEFORE PUSHING APP LIVE  
     logging.basicConfig(level=logging.DEBUG)
     app.logger.setLevel(logging.DEBUG)
 
+    from app.routes import upload  # To register our real file_upload() route
     # from .routes.user import user
     # app.register_blueprint(user)
 
@@ -17,9 +19,10 @@ def create_app(config_name="development"):
     def index():
         return render_template('index.html')
 
-    @app.route('/file_upload')
-    def file_upload():
-        return render_template('user/file_upload.html')
+    #Editing out the below while I troubleshoot getting Flask to run Forms
+    #@app.route('/file_upload')
+    #def file_upload():
+    #    return render_template('user/file_upload.html')
     
     @app.route('/login')
     def login():
@@ -51,5 +54,7 @@ def create_app(config_name="development"):
     #     from .models import User
     #     return User.query.get(int(user_id))
     
-    
+    from app.routes.upload import upload_bp
+    app.register_blueprint(upload_bp)
+
     return app

--- a/app/forms/file_upload_form.py
+++ b/app/forms/file_upload_form.py
@@ -1,0 +1,12 @@
+from flask_wtf import FlaskForm
+from flask_wtf.file import FileField, FileAllowed, FileRequired
+from wtforms import SubmitField
+# Above are the tools needed to use and validate flask forms
+
+class FileUploadForm(FlaskForm):
+    file = FileField('Upload CSV', validators=[
+        FileRequired(),
+        FileAllowed(['csv'], 'CSV files only!')
+    ])
+    submit = SubmitField('Upload')
+

--- a/app/routes/upload.py
+++ b/app/routes/upload.py
@@ -1,0 +1,26 @@
+from flask import Blueprint, render_template, flash, redirect, url_for
+from werkzeug.utils import secure_filename
+from app.forms.file_upload_form import FileUploadForm
+import os
+
+upload_bp = Blueprint('upload', __name__)
+
+@upload_bp.route('/file_upload', methods=['GET', 'POST'])
+def file_upload():
+    form = FileUploadForm()
+
+    if form.validate_on_submit():
+        file = form.file.data
+        if isinstance(file, list): #Checks in case the file is uploaded as a list
+            file = file[0]
+
+        filename = secure_filename(file.filename)
+
+        upload_folder = os.path.join('app/static/uploads')
+        os.makedirs(upload_folder, exist_ok=True)
+        file.save(os.path.join(upload_folder, filename))
+
+        flash('Upload successful!', 'success')
+        return redirect(url_for('upload.file_upload'))
+
+    return render_template('user/file_upload.html', form=form)

--- a/app/static/uploads/test_data.csv
+++ b/app/static/uploads/test_data.csv
@@ -1,0 +1,5 @@
+Date,Transaction Type,Coin,Amount,Price (USD)
+2024-04-01,Buy,BTC,0.005,30000
+2024-04-02,Buy,ETH,0.1,2000
+2024-04-03,Sell,BTC,0.0025,31000
+2024-04-04,Buy,ADA,500,0.45

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -15,7 +15,7 @@
     <div class="container">
     <h1>Crypto Tax, Made Tolerable</h1>
     <p class="tagline">Easily calculate your capital gains tax on crypto — fast, simple, accurate.</p>
-    <a href="{{ url_for('file_upload') }}" class="btn cta-button">Start Your Estimate</a>
+    <a href="{{ url_for('upload.file_upload') }}" class="cta-button">Start Your Estimate</a>
 
     <!-- kept these for now in case someone wants to re-use them on a different page
     <div class="features">

--- a/app/templates/user/file_upload.html
+++ b/app/templates/user/file_upload.html
@@ -10,6 +10,9 @@
         </div>
     </div>
     <div class="row px-4 mt-3 mb-3 flex-grow-1 d-flex">
+
+        <!-- JORDY: KEEPING THIS FOR NOW AS A REFERENCE FOR CSS -->
+        <!--
         <div class="col upload-area flex-column" id="uploadfile">
             <div class="upload-text">Drag and drop file here</div>
             <img id="upload-arrow" src="/static/images/upload-icon-white.png" alt="Upload Icon" width="80" height="80" alt="Upload Icon">
@@ -17,6 +20,25 @@
                 <a class="browse-link">Browse local files</a>
             </div>
         </div>
+        -->
+
+        <div class="col upload-area flex-column" id="uploadfile">
+            <form method="POST" enctype="multipart/form-data">
+                {{ form.hidden_tag() }}
+        
+                <div class="upload-text">Drag and drop file here</div>
+                <img id="upload-arrow" src="/static/images/upload-icon-white.png" alt="Upload Icon" width="80" height="80">
+        
+                <div class="upload-text">
+                    {{ form.file(class="form-control mb-3") }}
+                </div>
+        
+                <div class="upload-text">
+                    {{ form.submit(class="button-calculate btn w-100") }}
+                </div>
+            </form>
+        </div>
+
     </div>
     <div class="row px-4 mb-3 mt-auto">
         <div class="col-sm-3 px-0 ps-sm-0 pb-2 pb-sm-0">


### PR DESCRIPTION
## Overview of what this does
Adds a fully working file upload form that only accepts .csv files and saves them to static/uploads.

It uses Flask-WTF with CSRF functioning, it validates the file type to make sure it's csv and only saves it if it is.

### How to test
1. Run flask
2. go to ```/file_upload``` page in ya browser
3. Upload test_data.csv or your own test.csv (pls delete after)
4. The file *should* appear in ```app/static/uploads```
5. Try uploading different file extensions to make sure they don't appear in uploads folder.

#### notes
- There is no file parsing or database storage, it simply lets you upload a .csv file 
- There is currently no UI for a failed upload (I will implement this by deliverable 2)
- Styling is still basic and does not flow as well, hopefully we can fix this up by deliverable 2

@camhart21 @crypteemo @schain-dev 