### PR TITLE
test/isolate-pytest-db - Imported separate testing config when running tests to prevent data loss

### DIFF
--- a/config.py
+++ b/config.py
@@ -9,3 +9,12 @@ default_db_path = 'sqlite:///' + os.path.join(basedir, 'app.db')
 class Config:
     SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL') or default_db_path
     SECRET_KEY = os.environ.get('SECRET_KEY') or 'super-secret-private-key'
+
+# conftest loads this to completely isolate from rest of project
+class TestConfig:
+    TESTING = True
+    WTF_CSRF_ENABLED = False
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    TRAP_HTTP_EXCEPTIONS = True
+    PROPAGATE_EXCEPTIONS = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from app import create_app
 from app.models import User
 from app.extensions import db
 import app.constants as msg
+from config import TestConfig
 
 class UserSession:
     def __init__(self, client):
@@ -26,15 +27,11 @@ class UserSession:
 
 @pytest.fixture
 def app():
-    app = create_app()
-    app.config['TESTING'] = True
-    app.config['WTF_CSRF_ENABLED'] = False # disabled CSRF for testing POSTs
-    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:" # temp DB for testing
-    app.config['TRAP_HTTP_EXCEPTIONS'] = True
-    app.config['PROPAGATE_EXCEPTIONS'] = False
+    app = create_app(config_class=TestConfig)
+    
+    assert "sqlite" in app.config["SQLALCHEMY_DATABASE_URI"], "NOT using a test DB!"
 
     with app.app_context():
-        from app.extensions import db
         db.create_all()
         yield app
         db.session.remove()


### PR DESCRIPTION
### Fixed issue where running Pytest would wipe my dev database

- Introduced a dedicated TestConfig to isolate the test environment.
- Updated conftest.py to use this config during test app creation.
- Added a safety check to ensure tests only run against the test database.

This prevents accidental data loss during test runs