### PR TITLE
Added SharedSummary model and accompanying tests

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -70,7 +70,7 @@ class SharedSummary(db.Model):
     # mostly for debugging, unsure if this will feature in actual sharing
     timestamp = db.Column(
         db.DateTime,
-        default=datetime.utcnow,
+        default=datetime.now(),
         nullable=False
     )
 

--- a/app/models.py
+++ b/app/models.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from .extensions import db
 from flask_login import UserMixin
 from werkzeug.security import generate_password_hash, check_password_hash
@@ -31,7 +32,48 @@ class Admin(UserMixin):
         return True
 
 class Summary(db.Model):
-    id = db.Column(db.Integer, primary_key=True) 
-    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False) # makes sure there is an associated user_id for each summary
+    id = db.Column(db.Integer, primary_key=True) # makes sure there is an associated user_id for each summary
+    
+    user_id = db.Column(
+        db.Integer, 
+        db.ForeignKey('user.id'), 
+        nullable=False
+        ) 
+
     total_buy = db.Column(db.Float)
     total_sell = db.Column(db.Float)
+
+class SharedSummary(db.Model):
+    __tablename__ = 'shared_summary'
+    
+    id = db.Column(db.Integer, primary_key = True) # just to simplify queries if needed
+
+    # links to summary id
+    summary_id = db.Column(
+        db.Integer,
+        db.ForeignKey('summary.id'),
+        nullable=False
+    )
+
+    from_user_id = db.Column(
+        db.Integer,
+        db.ForeignKey('user.id'),
+        nullable=False
+    )
+
+    to_user_id = db.Column(
+        db.Integer,
+        db.ForeignKey('user.id'),
+        nullable=False
+    )
+
+    # mostly for debugging, unsure if this will feature in actual sharing
+    timestamp = db.Column(
+        db.DateTime,
+        default=datetime.utcnow,
+        nullable=False
+    )
+
+
+
+

--- a/tests/test_sharing_data.py
+++ b/tests/test_sharing_data.py
@@ -137,6 +137,6 @@ def test_create_and_query_shared_summary(app, two_users_and_summary):
     assert share.to_user_id    == sacha.id
 
     # timestamp default is “now”
-    now = datetime.utcnow()
+    now = datetime.now()
     assert isinstance(share.timestamp, datetime)
     assert now - share.timestamp < timedelta(seconds=5)


### PR DESCRIPTION
This PR introduces the SharedSummary join table, which enables users to share summaries with one another. The table includes foreign keys linking to users and summaries, along with a default UTC timestamp to track when shares occur.

## What’s included:
- SharedSummary SQLAlchemy model with:
- summary_id, from_user_id, to_user_id, timestamp
- Foreign key constraints and data integrity setup
- Default datetime.utcnow() for timestamp field
- Pytest fixture for creating test users and summaries
- 3 unit tests covering creation, field validation, and timestamp behavior


### Notes: 
- Need actual headers this is just the structure for now
- Unblocks other file-share issues
- Further pytest's may be needed dependent on agreed structure for visual and/or share-file


Fixes #67 